### PR TITLE
Option to deliver raw events to CloudWatch Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ The following configuration settings are supported:
   this setting provides a maximum batch size to use when clearing a large backlog of events, e.g.
   from system boot when the program starts for the first time.
 
+* `raw_message`: (Optional) Deliver the journal event directly to CloudWatch Logs without JSON
+  metadata. This is generally only useful if you're logging JSON to journald in the first place.
+
 Additionally values in the configuration file can contain variable expansions of the form
 ${instance.<key>} which will be exapnded from the AWS Instance Identity Document or ${env.<name>}
 which will be expanded from the operating system environment variables, if a key does not exist

--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Unit           string
 	JournalDir     string
 	BufferSize     int
+	RawMessage     bool
 }
 
 type fileConfig struct {
@@ -39,6 +40,7 @@ type fileConfig struct {
 	JournalDir    string `hcl:"journal_dir"`
 	Unit          string `hcl:"unit"`
 	BufferSize    int    `hcl:"buffer_size"`
+	RawMessage    bool   `hcl:"raw_message"`
 }
 
 func getLogLevel(priority string) (Priority, error) {
@@ -130,6 +132,7 @@ func LoadConfig(filename string) (*Config, error) {
 	config.StateFilename = fConfig.StateFilename
 	config.JournalDir = fConfig.JournalDir
 	config.Unit = fConfig.Unit
+	config.RawMessage = fConfig.RawMessage
 
 	if fConfig.BufferSize != 0 {
 		config.BufferSize = fConfig.BufferSize

--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func run(configFilename string) error {
 		awsSession,
 		config.LogGroupName,
 		config.LogStreamName,
+		config.RawMessage,
 		nextSeq,
 	)
 	if err != nil {

--- a/writer.go
+++ b/writer.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -34,6 +35,11 @@ func (w *Writer) WriteBatch(records []Record) (string, error) {
 
 	events := make([]*cloudwatchlogs.InputLogEvent, 0, len(records))
 	for _, record := range records {
+		// Skip records older than 24 hours or CloudWatch Logs will spew
+		if record.TimeUsec < time.Now().Add(-24*time.Hour).UnixNano()/1000 {
+			continue
+		}
+
 		var payload string
 		if w.rawMessage {
 			payload = record.Message


### PR DESCRIPTION
Option to deliver the journal event directly to CloudWatch Logs without JSON metadata. This is generally only useful if you're logging JSON to journald in the first place.